### PR TITLE
Add benchmark project and improve performance of constant array creation

### DIFF
--- a/ParquetSharp.Dataset.Benchmark/.gitignore
+++ b/ParquetSharp.Dataset.Benchmark/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts

--- a/ParquetSharp.Dataset.Benchmark/ApplyFilterMask.cs
+++ b/ParquetSharp.Dataset.Benchmark/ApplyFilterMask.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using Apache.Arrow;
+using BenchmarkDotNet.Attributes;
+using ParquetSharp.Dataset.Filter;
+
+namespace ParquetSharp.Dataset.Benchmark;
+
+public class ApplyFilterMask
+{
+    [Params(100, 1_000, 10_000)]
+    public int NumRows { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(0);
+
+        _intArray = new Int64Array.Builder()
+            .AppendRange(Enumerable.Range(0, NumRows).Select(_ => random.NextInt64(100)))
+            .Build();
+
+        var intBuilder = new Int64Array.Builder();
+        var mask = new byte[BitUtility.ByteCount(NumRows)];
+
+        for (var i = 0; i < NumRows; ++i)
+        {
+            BitUtility.SetBit(mask, i, random.NextDouble() < 0.5);
+            if (random.NextDouble() < 0.1)
+            {
+                intBuilder.AppendNull();
+            }
+            else
+            {
+                intBuilder.Append(random.NextInt64(100));
+            }
+        }
+
+        _nullableIntArray = intBuilder.Build();
+        _maskApplier = new ArrayMaskApplier(new FilterMask(mask));
+    }
+
+    [Benchmark]
+    public IArrowArray FilterInt64Array()
+    {
+        _intArray!.Accept(_maskApplier);
+        return _maskApplier!.MaskedArray;
+    }
+
+    [Benchmark]
+    public IArrowArray FilterNullableInt64Array()
+    {
+        _nullableIntArray!.Accept(_maskApplier);
+        return _maskApplier!.MaskedArray;
+    }
+
+    private IArrowArray? _intArray;
+    private IArrowArray? _nullableIntArray;
+    private ArrayMaskApplier? _maskApplier;
+}

--- a/ParquetSharp.Dataset.Benchmark/CreateConstantArray.cs
+++ b/ParquetSharp.Dataset.Benchmark/CreateConstantArray.cs
@@ -1,0 +1,35 @@
+using Apache.Arrow;
+using BenchmarkDotNet.Attributes;
+
+namespace ParquetSharp.Dataset.Benchmark;
+
+public class CreateConstantArray
+{
+    [Params(100, 1_000, 10_000)]
+    public int NumRows { get; set; }
+
+    public CreateConstantArray()
+    {
+        _intScalarArray = new Int32Array.Builder().Append(123).Build();
+        _stringScalarArray = new StringArray.Builder().Append("abcdefg").Build();
+    }
+
+    [Benchmark]
+    public IArrowArray CreateConstantIntArray()
+    {
+        var creator = new ConstantArrayCreator(NumRows);
+        _intScalarArray.Accept(creator);
+        return creator.Array!;
+    }
+
+    [Benchmark]
+    public IArrowArray CreateConstantStringArray()
+    {
+        var creator = new ConstantArrayCreator(NumRows);
+        _stringScalarArray.Accept(creator);
+        return creator.Array!;
+    }
+
+    private readonly IArrowArray _intScalarArray;
+    private readonly IArrowArray _stringScalarArray;
+}

--- a/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
+++ b/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using BenchmarkDotNet.Attributes;
+using ParquetSharp.Arrow;
+using ParquetSharp.Dataset.Partitioning;
+
+namespace ParquetSharp.Dataset.Benchmark;
+
+public class DatasetRead
+{
+    [GlobalSetup]
+    public void Setup()
+    {
+        _datasetDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        _allFiles.Clear();
+
+        var random = new Random(0);
+
+        const int numGroups = 10;
+        const int numDays = 10;
+        const int rowsPerFile = 10_000;
+
+        for (var groupNum = 0; groupNum < numGroups; ++groupNum)
+        {
+            var groupDirectory = Path.Join(_datasetDirectory, $"group=group-{groupNum}");
+            Directory.CreateDirectory(groupDirectory);
+            for (var dayNum = 0; dayNum < numDays; ++dayNum)
+            {
+                var dayDirectory = Path.Join(groupDirectory, $"day={dayNum}");
+                Directory.CreateDirectory(dayDirectory);
+                var filePath = Path.Join(dayDirectory, "data.parquet");
+                WriteDataFile(filePath, rowsPerFile, random);
+                _allFiles.Add(filePath);
+            }
+        }
+    }
+
+    private static void WriteDataFile(string filePath, int rowsPerFile, Random random)
+    {
+        var ids = new int[rowsPerFile];
+        var ints = new long[rowsPerFile];
+        var doubles = new double[rowsPerFile];
+
+        for (var i = 0; i < rowsPerFile; ++i)
+        {
+            ids[i] = (int)random.NextInt64(0, 100);
+            ints[i] = random.NextInt64(0, Int64.MaxValue);
+            doubles[i] = random.NextDouble() * 100.0;
+        }
+
+        var batch = new RecordBatch.Builder()
+            .Append("id", false, ab => ab.Int32(b => b.AppendRange(ids)))
+            .Append("ints", true, ab => ab.Int64(b => b.AppendRange(ints)))
+            .Append("doubles", true, ab => ab.Double(b => b.AppendRange(doubles)))
+            .Build();
+
+        using var writer = new FileWriter(filePath, batch.Schema);
+        writer.WriteRecordBatch(batch);
+        writer.Close();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Directory.Delete(_datasetDirectory, recursive: true);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<long> ReadAllFilesDirectly()
+    {
+        long rowsRead = 0;
+        foreach (var filePath in _allFiles)
+        {
+            using var reader = new FileReader(filePath);
+            using var batchReader = reader.GetRecordBatchReader();
+            while (await batchReader.ReadNextRecordBatchAsync() is { } batch)
+            {
+                rowsRead += batch.Length;
+            }
+        }
+
+        return rowsRead;
+    }
+
+    [Benchmark]
+    public async Task<long> ReadAllData()
+    {
+        var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
+        using var reader = dataset.ToBatches();
+        long rowsRead = 0;
+        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        {
+            rowsRead += batch.Length;
+        }
+
+        return rowsRead;
+    }
+
+    [Benchmark]
+    public async Task<long> FilterPartitions()
+    {
+        var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
+        var filter = Col.Named("group").IsEqualTo("group-2").And(Col.Named("day").IsEqualTo(2));
+        using var reader = dataset.ToBatches(filter);
+        long rowsRead = 0;
+        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        {
+            rowsRead += batch.Length;
+        }
+
+        return rowsRead;
+    }
+
+    [Benchmark]
+    public async Task<long> FilterFileData()
+    {
+        var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
+        var filter = Col.Named("id").IsEqualTo(5);
+        using var reader = dataset.ToBatches(filter);
+        long rowsRead = 0;
+        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        {
+            rowsRead += batch.Length;
+        }
+
+        return rowsRead;
+    }
+
+    [Benchmark]
+    public async Task<long> FilterToFileColumns()
+    {
+        var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
+        using var reader = dataset.ToBatches(columns: new[] { "id", "ints", "doubles" });
+        long rowsRead = 0;
+        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        {
+            rowsRead += batch.Length;
+        }
+
+        return rowsRead;
+    }
+
+    [Benchmark]
+    public async Task<long> FilterToSingleColumn()
+    {
+        var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
+        using var reader = dataset.ToBatches(columns: new[] { "ints" });
+        long rowsRead = 0;
+        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        {
+            rowsRead += batch.Length;
+        }
+
+        return rowsRead;
+    }
+
+    private string _datasetDirectory = "";
+    private readonly List<string> _allFiles = new();
+}

--- a/ParquetSharp.Dataset.Benchmark/ParquetSharp.Dataset.Benchmark.csproj
+++ b/ParquetSharp.Dataset.Benchmark/ParquetSharp.Dataset.Benchmark.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ParquetSharp.Dataset\ParquetSharp.Dataset.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+</Project>

--- a/ParquetSharp.Dataset.Benchmark/Program.cs
+++ b/ParquetSharp.Dataset.Benchmark/Program.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace ParquetSharp.Dataset.Benchmark;
+
+internal static class Program
+{
+    public static void Main(string[] args)
+    {
+        var config = DefaultConfig.Instance
+            .WithOptions(ConfigOptions.Default | ConfigOptions.StopOnFirstError)
+            .AddJob(Job.ShortRun);
+
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+    }
+}

--- a/ParquetSharp.Dataset.sln
+++ b/ParquetSharp.Dataset.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParquetSharp.Dataset", "Par
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParquetSharp.Dataset.Test", "ParquetSharp.Dataset.Test\ParquetSharp.Dataset.Test.csproj", "{826AF241-4060-4D57-896A-19138A9C5DBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParquetSharp.Dataset.Benchmark", "ParquetSharp.Dataset.Benchmark\ParquetSharp.Dataset.Benchmark.csproj", "{FFF22C4C-D90F-4753-A427-BB0BB49F5794}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{826AF241-4060-4D57-896A-19138A9C5DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{826AF241-4060-4D57-896A-19138A9C5DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{826AF241-4060-4D57-896A-19138A9C5DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFF22C4C-D90F-4753-A427-BB0BB49F5794}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFF22C4C-D90F-4753-A427-BB0BB49F5794}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFF22C4C-D90F-4753-A427-BB0BB49F5794}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFF22C4C-D90F-4753-A427-BB0BB49F5794}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/ParquetSharp.Dataset/ConstantArrayCreator.cs
+++ b/ParquetSharp.Dataset/ConstantArrayCreator.cs
@@ -26,42 +26,42 @@ internal sealed class ConstantArrayCreator
 
     public void Visit(UInt8Array array)
     {
-        VisitPrimitiveArray<byte, UInt8Array, UInt8Array.Builder>(array);
+        Array = new UInt8Array(VisitPrimitiveArray<byte, UInt8Array>(array));
     }
 
     public void Visit(UInt16Array array)
     {
-        VisitPrimitiveArray<ushort, UInt16Array, UInt16Array.Builder>(array);
+        Array = new UInt16Array(VisitPrimitiveArray<ushort, UInt16Array>(array));
     }
 
     public void Visit(UInt32Array array)
     {
-        VisitPrimitiveArray<uint, UInt32Array, UInt32Array.Builder>(array);
+        Array = new UInt32Array(VisitPrimitiveArray<uint, UInt32Array>(array));
     }
 
     public void Visit(UInt64Array array)
     {
-        VisitPrimitiveArray<ulong, UInt64Array, UInt64Array.Builder>(array);
+        Array = new UInt64Array(VisitPrimitiveArray<ulong, UInt64Array>(array));
     }
 
     public void Visit(Int8Array array)
     {
-        VisitPrimitiveArray<sbyte, Int8Array, Int8Array.Builder>(array);
+        Array = new Int8Array(VisitPrimitiveArray<sbyte, Int8Array>(array));
     }
 
     public void Visit(Int16Array array)
     {
-        VisitPrimitiveArray<short, Int16Array, Int16Array.Builder>(array);
+        Array = new Int16Array(VisitPrimitiveArray<short, Int16Array>(array));
     }
 
     public void Visit(Int32Array array)
     {
-        VisitPrimitiveArray<int, Int32Array, Int32Array.Builder>(array);
+        Array = new Int32Array(VisitPrimitiveArray<int, Int32Array>(array));
     }
 
     public void Visit(Int64Array array)
     {
-        VisitPrimitiveArray<long, Int64Array, Int64Array.Builder>(array);
+        Array = new Int64Array(VisitPrimitiveArray<long, Int64Array>(array));
     }
 
     public void Visit(StringArray array)
@@ -93,30 +93,33 @@ internal sealed class ConstantArrayCreator
             $"Cannot create a constant array with type {array.Data.DataType.Name}");
     }
 
-    private void VisitPrimitiveArray<T, TArray, TBuilder>(TArray array)
+    private ArrayData VisitPrimitiveArray<T, TArray>(TArray array)
         where T : struct
         where TArray : PrimitiveArray<T>
-        where TBuilder : PrimitiveArrayBuilder<T, TArray, TBuilder>, new()
     {
-        var builder = new TBuilder();
-        builder.Reserve(_arrayLength);
         var value = array.GetValue(0);
         if (value.HasValue)
         {
-            for (var i = 0; i < _arrayLength; ++i)
-            {
-                builder.Append(value.Value);
-            }
+            var valueBuilder = new ArrowBuffer.Builder<T>(_arrayLength);
+            valueBuilder.Resize(_arrayLength);
+            valueBuilder.Span.Fill(value.Value);
+            var valueBuffer = valueBuilder.Build();
+
+            return new ArrayData(array.Data.DataType, _arrayLength, 0, 0, new[] { ArrowBuffer.Empty, valueBuffer });
         }
         else
         {
-            for (var i = 0; i < _arrayLength; ++i)
-            {
-                builder.AppendNull();
-            }
-        }
+            var valueBuilder = new ArrowBuffer.Builder<T>(_arrayLength);
+            valueBuilder.Resize(_arrayLength);
+            valueBuilder.Span.Fill(default);
+            var valueBuffer = valueBuilder.Build();
 
-        Array = builder.Build();
+            var validityBuilder = new ArrowBuffer.BitmapBuilder(_arrayLength);
+            validityBuilder.AppendRange(false, _arrayLength);
+            var validityBuffer = validityBuilder.Build();
+
+            return new ArrayData(array.Data.DataType, _arrayLength, _arrayLength, 0, new[] { validityBuffer, valueBuffer });
+        }
     }
 
 

--- a/ParquetSharp.Dataset/ConstantArrayCreator.cs
+++ b/ParquetSharp.Dataset/ConstantArrayCreator.cs
@@ -129,7 +129,9 @@ internal sealed class ConstantArrayCreator
             valueBuilder.Span.Fill(value.Value);
             var valueBuffer = valueBuilder.Build();
 
-            return new ArrayData(array.Data.DataType, _arrayLength, 0, 0, new[] { ArrowBuffer.Empty, valueBuffer });
+            return new ArrayData(
+                array.Data.DataType, length: _arrayLength, nullCount: 0, offset: 0,
+                new[] { ArrowBuffer.Empty, valueBuffer });
         }
         else
         {
@@ -142,7 +144,9 @@ internal sealed class ConstantArrayCreator
             validityBuilder.AppendRange(false, _arrayLength);
             var validityBuffer = validityBuilder.Build();
 
-            return new ArrayData(array.Data.DataType, _arrayLength, _arrayLength, 0, new[] { validityBuffer, valueBuffer });
+            return new ArrayData(
+                array.Data.DataType, length: _arrayLength, nullCount: _arrayLength, offset: 0,
+                new[] { validityBuffer, valueBuffer });
         }
     }
 

--- a/ParquetSharp.Dataset/InternalsVisibleTo.cs
+++ b/ParquetSharp.Dataset/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ParquetSharp.Dataset.Test")]
+[assembly: InternalsVisibleTo("ParquetSharp.Dataset.Benchmark")]


### PR DESCRIPTION
This PR adds a `ParquetSharp.Dataset.Benchmark` project that uses BenchmarkDotNet. I've added some high-level benchmarks of dataset reading, and then micro benchmarks for creating constant valued arrays and applying filters.

Creating the constant columns for fields from the partitioning schema was taking a particularly long amount of time, causing the "ReadAllData" benchmark to be much slower than reading all files with ParquetSharp directly (the "ReadAllFilesDirectly") benchmark, so I've sped that up significantly.

I also improved the performance of filtering primitive arrays that don't have nulls present. This wasn't taking a significant amount of time in the high level benchmark but would be more important for filtering data with a large number of columns.

Benchmark results from my machine are:

## DatasetRead

Before:

| Method               | Mean      | Error     | StdDev    | Ratio | RatioSD |
|--------------------- |----------:|----------:|----------:|------:|--------:|
| ReadAllFilesDirectly | 21.133 ms |  2.266 ms | 0.1242 ms |  1.00 |    0.00 |
| ReadAllData          | 87.099 ms |  2.420 ms | 0.1326 ms |  4.12 |    0.03 |
| FilterPartitions     |  1.324 ms |  1.019 ms | 0.0558 ms |  0.06 |    0.00 |
| FilterFileData       | 49.531 ms | 17.072 ms | 0.9358 ms |  2.34 |    0.05 |
| FilterToFileColumns  | 27.018 ms |  4.716 ms | 0.2585 ms |  1.28 |    0.01 |
| FilterToSingleColumn | 16.426 ms |  1.302 ms | 0.0714 ms |  0.78 |    0.01 |

After:

| Method               | Mean        | Error        | StdDev    | Ratio | RatioSD |
|--------------------- |------------:|-------------:|----------:|------:|--------:|
| ReadAllFilesDirectly | 22,034.4 μs |  5,350.88 μs | 293.30 μs |  1.00 |    0.00 |
| ReadAllData          | 33,189.4 μs |  2,864.13 μs | 156.99 μs |  1.51 |    0.03 |
| FilterPartitions     |    785.8 μs |     39.23 μs |   2.15 μs |  0.04 |    0.00 |
| FilterFileData       | 47,252.1 μs | 10,079.04 μs | 552.47 μs |  2.14 |    0.01 |
| FilterToFileColumns  | 24,265.1 μs |  1,529.44 μs |  83.83 μs |  1.10 |    0.01 |
| FilterToSingleColumn | 16,486.8 μs | 15,736.79 μs | 862.59 μs |  0.75 |    0.05 |

## CreateConstantArray

Before:

| Method                    | NumRows | Mean       | Error       | StdDev    |
|-------------------------- |-------- |-----------:|------------:|----------:|
| **CreateConstantIntArray**    | **100**     |   **2.115 μs** |   **0.0935 μs** | **0.0051 μs** |
| CreateConstantStringArray | 100     |   5.121 μs |   0.5213 μs | 0.0286 μs |
| **CreateConstantIntArray**    | **1000**    |  **12.606 μs** |   **0.3827 μs** | **0.0210 μs** |
| CreateConstantStringArray | 1000    |  37.598 μs |   6.9776 μs | 0.3825 μs |
| **CreateConstantIntArray**    | **10000**   | **128.637 μs** |   **8.0865 μs** | **0.4432 μs** |
| CreateConstantStringArray | 10000   | 399.849 μs | 105.8396 μs | 5.8014 μs |

After:

| Method                    | NumRows | Mean        | Error     | StdDev   |
|-------------------------- |-------- |------------:|----------:|---------:|
| **CreateConstantIntArray**    | **100**     |  **1,221.9 ns** | **250.79 ns** | **13.75 ns** |
| CreateConstantStringArray | 100     |  2,712.4 ns | 739.45 ns | 40.53 ns |
| **CreateConstantIntArray**    | **1000**    |    **816.8 ns** |  **99.03 ns** |  **5.43 ns** |
| CreateConstantStringArray | 1000    |  5,612.4 ns | 421.04 ns | 23.08 ns |
| **CreateConstantIntArray**    | **10000**   |  **3,463.7 ns** |  **60.49 ns** |  **3.32 ns** |
| CreateConstantStringArray | 10000   | 35,203.2 ns | 882.23 ns | 48.36 ns |

## ApplyFilterMask

Before:

| Method                   | NumRows | Mean       | Error      | StdDev    |
|------------------------- |-------- |-----------:|-----------:|----------:|
| **FilterInt64Array**         | **100**     |   **2.625 μs** |  **0.2909 μs** | **0.0159 μs** |
| FilterNullableInt64Array | 100     |   3.230 μs |  0.2394 μs | 0.0131 μs |
| **FilterInt64Array**         | **1000**    |   **8.842 μs** |  **0.5678 μs** | **0.0311 μs** |
| FilterNullableInt64Array | 1000    |  15.823 μs |  3.9359 μs | 0.2157 μs |
| **FilterInt64Array**         | **10000**   | **100.862 μs** | **14.9931 μs** | **0.8218 μs** |
| FilterNullableInt64Array | 10000   | 180.643 μs |  1.1782 μs | 0.0646 μs |

After:

| Method                   | NumRows | Mean       | Error      | StdDev    |
|------------------------- |-------- |-----------:|-----------:|----------:|
| **FilterInt64Array**         | **100**     |   **1.365 μs** |  **0.2347 μs** | **0.0129 μs** |
| FilterNullableInt64Array | 100     |   2.953 μs |  5.3568 μs | 0.2936 μs |
| **FilterInt64Array**         | **1000**    |   **3.130 μs** |  **0.3341 μs** | **0.0183 μs** |
| FilterNullableInt64Array | 1000    |  15.758 μs |  1.2079 μs | 0.0662 μs |
| **FilterInt64Array**         | **10000**   |  **26.081 μs** |  **1.0576 μs** | **0.0580 μs** |
| FilterNullableInt64Array | 10000   | 188.546 μs | 27.3601 μs | 1.4997 μs |
