### PR TITLE
Return query results ordered by partition values

### DIFF
--- a/ParquetSharp.Dataset/FragmentEnumerator.cs
+++ b/ParquetSharp.Dataset/FragmentEnumerator.cs
@@ -33,6 +33,12 @@ internal sealed class PartitionFragment
     public PartitionInformation PartitionInformation { get; }
 }
 
+internal struct DirectoryListing
+{
+    public string[] Files;
+    public string[] Directories;
+}
+
 /// <summary>
 /// Enumerator over data files in a dataset directory
 /// </summary>
@@ -68,23 +74,20 @@ internal sealed class FragmentEnumerator : IEnumerator<PartitionFragment>
 
             var directoryPath = Path.Join(_rootDirectory, Path.Join(pathComponents));
             var directoryInfo = new DirectoryInfo(directoryPath);
-            foreach (var fsi in directoryInfo.GetFileSystemInfos())
+            var directoryListing = ListDirectory(directoryInfo);
+            foreach (var directoryName in directoryListing.Directories)
             {
-                if ((fsi.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                var subdirectoryComponents = new string[pathComponents.Length + 1];
+                Array.Copy(pathComponents, subdirectoryComponents, pathComponents.Length);
+                subdirectoryComponents[pathComponents.Length] = directoryName;
+                _directoryQueue.Enqueue(subdirectoryComponents);
+            }
+
+            foreach (var fileName in directoryListing.Files)
+            {
+                if (Path.GetExtension(fileName).Equals(".parquet", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Subdirectory
-                    var subdirectoryComponents = new string[pathComponents.Length + 1];
-                    Array.Copy(pathComponents, subdirectoryComponents, pathComponents.Length);
-                    subdirectoryComponents[pathComponents.Length] = fsi.Name;
-                    _directoryQueue.Enqueue(subdirectoryComponents);
-                }
-                else
-                {
-                    // File
-                    if (fsi.Extension.Equals(".parquet", StringComparison.OrdinalIgnoreCase))
-                    {
-                        _fileQueue.Enqueue(fsi.FullName);
-                    }
+                    _fileQueue.Enqueue(Path.Join(directoryPath, fileName));
                 }
             }
         }
@@ -120,6 +123,29 @@ internal sealed class FragmentEnumerator : IEnumerator<PartitionFragment>
 
     public void Dispose()
     {
+    }
+
+    private static DirectoryListing ListDirectory(DirectoryInfo directory)
+    {
+        var directories = new List<string>();
+        var files = new List<string>();
+        foreach (var fsi in directory.GetFileSystemInfos())
+        {
+            if ((fsi.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                directories.Add(fsi.Name);
+            }
+            else
+            {
+                files.Add(fsi.Name);
+            }
+        }
+
+        return new DirectoryListing
+        {
+            Directories = directories.ToArray(),
+            Files = files.ToArray(),
+        };
     }
 
     private readonly IFilter? _filter;

--- a/ParquetSharp.Dataset/FragmentEnumerator.cs
+++ b/ParquetSharp.Dataset/FragmentEnumerator.cs
@@ -75,6 +75,12 @@ internal sealed class FragmentEnumerator : IEnumerator<PartitionFragment>
             var directoryPath = Path.Join(_rootDirectory, Path.Join(pathComponents));
             var directoryInfo = new DirectoryInfo(directoryPath);
             var directoryListing = ListDirectory(directoryInfo);
+
+            // Sort directories according to partitioning values,
+            // and ensure consistent file ordering within a directory
+            _partitioning.SortDirectories(pathComponents, directoryListing.Directories);
+            Array.Sort(directoryListing.Files, StringComparer.Ordinal);
+
             foreach (var directoryName in directoryListing.Directories)
             {
                 var subdirectoryComponents = new string[pathComponents.Length + 1];

--- a/ParquetSharp.Dataset/IPartitioning.cs
+++ b/ParquetSharp.Dataset/IPartitioning.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ParquetSharp.Dataset;
 
 public interface IPartitioning
@@ -15,5 +17,12 @@ public interface IPartitioning
     /// </summary>
     /// <param name="pathComponents">Relative path within a dataset, split into components</param>
     /// <returns>The parsed partition information.</returns>
-    PartitionInformation Parse(string[] pathComponents);
+    PartitionInformation Parse(IReadOnlyList<string> pathComponents);
+
+    /// <summary>
+    /// Sort partition directories according to partition field values
+    /// </summary>
+    /// <param name="parentPath">The path containing the directories</param>
+    /// <param name="directoryNames">Array of directory names to be sorted</param>
+    void SortDirectories(IReadOnlyList<string> parentPath, string[] directoryNames);
 }

--- a/ParquetSharp.Dataset/IPartitioningFactory.cs
+++ b/ParquetSharp.Dataset/IPartitioningFactory.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ParquetSharp.Dataset;
 
 public interface IPartitioningFactory
@@ -6,7 +8,7 @@ public interface IPartitioningFactory
     /// Visit a subdirectory containing a data file
     /// </summary>
     /// <param name="pathComponents">Array of directory names containing a data file</param>
-    void Inspect(string[] pathComponents);
+    void Inspect(IReadOnlyList<string> pathComponents);
 
     /// <summary>
     /// Create the partitioning from seen subdirectories

--- a/ParquetSharp.Dataset/Partitioning/HivePartitioning.cs
+++ b/ParquetSharp.Dataset/Partitioning/HivePartitioning.cs
@@ -14,7 +14,7 @@ public sealed class HivePartitioning : IPartitioning
 {
     public sealed class Factory : IPartitioningFactory
     {
-        public void Inspect(string[] pathComponents)
+        public void Inspect(IReadOnlyList<string> pathComponents)
         {
             foreach (var dirName in pathComponents)
             {
@@ -66,10 +66,10 @@ public sealed class HivePartitioning : IPartitioning
 
     public Apache.Arrow.Schema Schema { get; }
 
-    public PartitionInformation Parse(string[] pathComponents)
+    public PartitionInformation Parse(IReadOnlyList<string> pathComponents)
     {
-        var arrays = new List<IArrowArray>(pathComponents.Length);
-        var fields = new List<Field>(pathComponents.Length);
+        var arrays = new List<IArrowArray>(pathComponents.Count);
+        var fields = new List<Field>(pathComponents.Count);
 
         foreach (var dirName in pathComponents)
         {
@@ -107,6 +107,11 @@ public sealed class HivePartitioning : IPartitioning
         }
 
         return new PartitionInformation(new RecordBatch(schemaBuilder.Build(), arrays, 1));
+    }
+
+    public void SortDirectories(IReadOnlyList<string> parentPath, string[] directoryNames)
+    {
+        System.Array.Sort(directoryNames, StringComparer.Ordinal);
     }
 
     private static (string, string) ParseDirectoryName(string directoryName)

--- a/ParquetSharp.Dataset/Partitioning/NoPartitioning.cs
+++ b/ParquetSharp.Dataset/Partitioning/NoPartitioning.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ParquetSharp.Dataset.Partitioning;
 
 /// <summary>
@@ -7,7 +10,7 @@ public sealed class NoPartitioning : IPartitioning
 {
     public sealed class Factory : IPartitioningFactory
     {
-        public void Inspect(string[] pathComponents)
+        public void Inspect(IReadOnlyList<string> pathComponents)
         {
         }
 
@@ -19,9 +22,14 @@ public sealed class NoPartitioning : IPartitioning
 
     public Apache.Arrow.Schema Schema => EmptySchema;
 
-    public PartitionInformation Parse(string[] pathComponents)
+    public PartitionInformation Parse(IReadOnlyList<string> pathComponents)
     {
         return PartitionInformation.Empty;
+    }
+
+    public void SortDirectories(IReadOnlyList<string> parentPath, string[] directoryNames)
+    {
+        Array.Sort(directoryNames, StringComparer.Ordinal);
     }
 
     private static readonly Apache.Arrow.Schema EmptySchema = new Apache.Arrow.Schema.Builder().Build();


### PR DESCRIPTION
This PR ensures results are always returned in a consistent order, and when using Hive partitioning with integer partition fields, the results are ordered by the integer field values.