### PR TITLE
Improve performance of computing filter masks

### DIFF
--- a/ParquetSharp.Dataset.Benchmark/ComputeFilterMask.cs
+++ b/ParquetSharp.Dataset.Benchmark/ComputeFilterMask.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using Apache.Arrow;
+using BenchmarkDotNet.Attributes;
+using ParquetSharp.Dataset.Filter;
+
+namespace ParquetSharp.Dataset.Benchmark;
+
+public class ComputeFilterMask
+{
+    [Params(100, 1_000, 10_000)]
+    public int NumRows { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(0);
+
+        var strings = new[] { "a", "bc", "def", "ghij", "klmno", "pqrstu", "vwxyz" };
+
+        _stringArray = new StringArray.Builder()
+            .AppendRange(Enumerable.Range(0, NumRows).Select(_ => strings[random.NextInt64(strings.Length)]))
+            .Build();
+        _intArray = new Int64Array.Builder()
+            .AppendRange(Enumerable.Range(0, NumRows).Select(_ => random.NextInt64(100)))
+            .Build();
+        _dateArray = new Date32Array.Builder()
+            .AppendRange(Enumerable.Range(0, NumRows).Select(_ => new DateOnly(2024, 1, 1).AddDays((int)random.NextInt64(100))))
+            .Build();
+
+        var stringBuilder = new StringArray.Builder();
+        var intBuilder = new Int64Array.Builder();
+        var dateBuilder = new Date32Array.Builder();
+
+        for (var i = 0; i < NumRows; ++i)
+        {
+            if (random.NextDouble() < 0.1)
+            {
+                stringBuilder.AppendNull();
+                intBuilder.AppendNull();
+                dateBuilder.AppendNull();
+            }
+            else
+            {
+                stringBuilder.Append(strings[random.NextInt64(strings.Length)]);
+                intBuilder.Append(random.NextInt64(100));
+                dateBuilder.Append(new DateOnly(2024, 1, 1).AddDays((int)random.NextInt64(100)));
+            }
+        }
+
+        _nullableStringArray = stringBuilder.Build();
+        _nullableIntArray = intBuilder.Build();
+        _nullableDateArray = dateBuilder.Build();
+    }
+
+    [Benchmark]
+    public byte[] ComputeIntEqualityMask()
+    {
+        var evaluator = new IntEqualityEvaluator(10, "x");
+        _intArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeIntEqualityMaskWithNullableArray()
+    {
+        var evaluator = new IntEqualityEvaluator(10, "x");
+        _nullableIntArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeIntRangeMask()
+    {
+        var evaluator = new IntRangeEvaluator(10, 20, "x");
+        _intArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeIntRangeMaskWithNullableArray()
+    {
+        var evaluator = new IntRangeEvaluator(10, 20, "x");
+        _nullableIntArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeDateRangeMask()
+    {
+        var evaluator = new DateRangeEvaluator(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 29), "x");
+        _dateArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeDateRangeMaskWithNullableArray()
+    {
+        var evaluator = new DateRangeEvaluator(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 29), "x");
+        _nullableDateArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeStringMask()
+    {
+        var evaluator = new StringInSetEvaluator(new[] { "bc", "def" }, "x");
+        _stringArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    [Benchmark]
+    public byte[] ComputeStringMaskWithNullableArray()
+    {
+        var evaluator = new StringInSetEvaluator(new[] { "bc", "def" }, "x");
+        _nullableStringArray!.Accept(evaluator);
+        return evaluator.FilterResult;
+    }
+
+    private IArrowArray? _stringArray;
+    private IArrowArray? _nullableStringArray;
+    private IArrowArray? _intArray;
+    private IArrowArray? _nullableIntArray;
+    private IArrowArray? _dateArray;
+    private IArrowArray? _nullableDateArray;
+}

--- a/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
@@ -22,17 +22,34 @@ internal sealed class DateRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            for (var i = 0; i < inputArray.Length; ++i)
+            var startNumber = _start.DayNumber - ArrowEpoch.DayNumber;
+            var endNumber = _end.DayNumber - ArrowEpoch.DayNumber;
+            if (inputArray.NullCount == 0)
             {
-                var value = array.GetDateOnly(i);
-                var isInRange = value.HasValue && value.Value >= _start && value.Value <= _end;
-                BitUtility.SetBit(mask, i, isInRange);
+                var values = array.Values;
+                for (var i = 0; i < inputArray.Length; ++i)
+                {
+                    var value = values[i];
+                    var isInRange = value >= startNumber && value <= endNumber;
+                    BitUtility.SetBit(mask, i, isInRange);
+                }
+            }
+            else
+            {
+                for (var i = 0; i < inputArray.Length; ++i)
+                {
+                    var value = array.GetValue(i);
+                    var isInRange = value.HasValue && value.Value >= startNumber && value.Value <= endNumber;
+                    BitUtility.SetBit(mask, i, isInRange);
+                }
             }
         });
     }
 
     public void Visit(Date64Array array)
     {
+        // A Date64Array holds the number of milliseconds since the UNIX epoch,
+        // so the conversion from a long value to a date isn't as simple as for Date32
         BuildMask(array, (mask, inputArray) =>
         {
             for (var i = 0; i < inputArray.Length; ++i)
@@ -49,6 +66,8 @@ internal sealed class DateRangeEvaluator :
         throw new NotSupportedException(
             $"Date range filter for column '{_columnName}' does not support arrays with type {array.Data.DataType.Name}");
     }
+
+    private static readonly DateOnly ArrowEpoch = new DateOnly(1970, 1, 1);
 
     private readonly DateOnly _start;
     private readonly DateOnly _end;

--- a/ParquetSharp.Dataset/Filter/IntEqualityEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/IntEqualityEvaluator.cs
@@ -33,11 +33,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (byte)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (byte)_expectedValue);
             }
         });
     }
@@ -52,11 +48,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (ushort)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (ushort)_expectedValue);
             }
         });
     }
@@ -71,11 +63,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (uint)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (uint)_expectedValue);
             }
         });
     }
@@ -90,11 +78,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (ulong)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (ulong)_expectedValue);
             }
         });
     }
@@ -109,11 +93,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (sbyte)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (sbyte)_expectedValue);
             }
         });
     }
@@ -128,11 +108,7 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (short)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (short)_expectedValue);
             }
         });
     }
@@ -147,24 +123,35 @@ internal sealed class IntEqualityEvaluator :
             }
             else
             {
-                var expectedValue = (int)_expectedValue;
-                for (var i = 0; i < inputArray.Length; ++i)
-                {
-                    BitUtility.SetBit(mask, i, inputArray.GetValue(i) == expectedValue);
-                }
+                ComputeMask(mask, inputArray, (int)_expectedValue);
             }
         });
     }
 
     public void Visit(Int64Array array)
     {
-        BuildMask(array, (mask, inputArray) =>
+        BuildMask(array, (mask, inputArray) => { ComputeMask(mask, inputArray, _expectedValue); });
+    }
+
+    private static void ComputeMask<T, TArray>(byte[] mask, TArray array, T expectedValue)
+        where T : struct, IEquatable<T>
+        where TArray : PrimitiveArray<T>
+    {
+        if (array.NullCount == 0)
         {
-            for (var i = 0; i < inputArray.Length; ++i)
+            var values = array.Values;
+            for (var i = 0; i < array.Length; ++i)
             {
-                BitUtility.SetBit(mask, i, inputArray.GetValue(i) == _expectedValue);
+                BitUtility.SetBit(mask, i, values[i].Equals(expectedValue));
             }
-        });
+        }
+        else
+        {
+            for (var i = 0; i < array.Length; ++i)
+            {
+                BitUtility.SetBit(mask, i, array.GetValue(i).Equals(expectedValue));
+            }
+        }
     }
 
     public override void Visit(IArrowArray array)


### PR DESCRIPTION
This speeds up computing filter masks for integer and date filters, mostly by optimizing the case where the array is known to have no null values, so the null check can be skipped.

Benchmark results before optimizations:

| Method                                  | NumRows | Mean         | Error       | StdDev     |
|---------------------------------------- |-------- |-------------:|------------:|-----------:|
| **ComputeIntEqualityMask**                  | **100**     |     **1.384 μs** |   **0.0482 μs** |  **0.0026 μs** |
| ComputeIntEqualityMaskWithNullableArray | 100     |     3.139 μs |   0.0731 μs |  0.0040 μs |
| ComputeIntRangeMask                     | 100     |     1.513 μs |   0.7365 μs |  0.0404 μs |
| ComputeIntRangeMaskWithNullableArray    | 100     |     3.298 μs |   0.5293 μs |  0.0290 μs |
| ComputeDateRangeMask                    | 100     |     2.178 μs |   0.6386 μs |  0.0350 μs |
| ComputeDateRangeMaskWithNullableArray   | 100     |     3.743 μs |   0.4000 μs |  0.0219 μs |
| ComputeStringMask                       | 100     |     6.862 μs |   0.7430 μs |  0.0407 μs |
| ComputeStringMaskWithNullableArray      | 100     |    10.479 μs |   0.5818 μs |  0.0319 μs |
| **ComputeIntEqualityMask**                  | **1000**    |    **12.969 μs** |   **0.4129 μs** |  **0.0226 μs** |
| ComputeIntEqualityMaskWithNullableArray | 1000    |    33.011 μs |  21.1007 μs |  1.1566 μs |
| ComputeIntRangeMask                     | 1000    |    15.100 μs |   2.3441 μs |  0.1285 μs |
| ComputeIntRangeMaskWithNullableArray    | 1000    |    33.589 μs |  14.4407 μs |  0.7915 μs |
| ComputeDateRangeMask                    | 1000    |    24.101 μs |   4.3073 μs |  0.2361 μs |
| ComputeDateRangeMaskWithNullableArray   | 1000    |    43.769 μs |   1.4644 μs |  0.0803 μs |
| ComputeStringMask                       | 1000    |    75.660 μs |   7.8289 μs |  0.4291 μs |
| ComputeStringMaskWithNullableArray      | 1000    |   103.037 μs |   6.3109 μs |  0.3459 μs |
| **ComputeIntEqualityMask**                  | **10000**   |   **135.234 μs** |   **5.0512 μs** |  **0.2769 μs** |
| ComputeIntEqualityMaskWithNullableArray | 10000   |   312.840 μs |   8.2627 μs |  0.4529 μs |
| ComputeIntRangeMask                     | 10000   |   157.829 μs |  16.5456 μs |  0.9069 μs |
| ComputeIntRangeMaskWithNullableArray    | 10000   |   344.848 μs | 143.3870 μs |  7.8595 μs |
| ComputeDateRangeMask                    | 10000   |   292.337 μs |  30.8814 μs |  1.6927 μs |
| ComputeDateRangeMaskWithNullableArray   | 10000   |   458.569 μs |   6.8777 μs |  0.3770 μs |
| ComputeStringMask                       | 10000   |   751.143 μs | 184.5456 μs | 10.1156 μs |
| ComputeStringMaskWithNullableArray      | 10000   | 1,022.997 μs |  41.2680 μs |  2.2620 μs |

Benchmark results after:

| Method                                  | NumRows | Mean           | Error        | StdDev      |
|---------------------------------------- |-------- |---------------:|-------------:|------------:|
| **ComputeIntEqualityMask**                  | **100**     |       **203.0 ns** |     **12.95 ns** |     **0.71 ns** |
| ComputeIntEqualityMaskWithNullableArray | 100     |     3,512.8 ns |    170.98 ns |     9.37 ns |
| ComputeIntRangeMask                     | 100     |       303.0 ns |      6.62 ns |     0.36 ns |
| ComputeIntRangeMaskWithNullableArray    | 100     |     3,157.9 ns |     96.30 ns |     5.28 ns |
| ComputeDateRangeMask                    | 100     |       235.3 ns |     28.08 ns |     1.54 ns |
| ComputeDateRangeMaskWithNullableArray   | 100     |     3,039.7 ns |  1,045.57 ns |    57.31 ns |
| ComputeStringMask                       | 100     |     8,166.5 ns |  2,223.18 ns |   121.86 ns |
| ComputeStringMaskWithNullableArray      | 100     |    10,052.3 ns |    814.14 ns |    44.63 ns |
| **ComputeIntEqualityMask**                  | **1000**    |     **1,642.2 ns** |    **431.82 ns** |    **23.67 ns** |
| ComputeIntEqualityMaskWithNullableArray | 1000    |    33,326.4 ns |  1,609.16 ns |    88.20 ns |
| ComputeIntRangeMask                     | 1000    |     2,915.8 ns |     93.81 ns |     5.14 ns |
| ComputeIntRangeMaskWithNullableArray    | 1000    |    31,064.6 ns |  5,060.87 ns |   277.40 ns |
| ComputeDateRangeMask                    | 1000    |     2,117.3 ns |     70.90 ns |     3.89 ns |
| ComputeDateRangeMaskWithNullableArray   | 1000    |    34,534.9 ns |  6,750.05 ns |   369.99 ns |
| ComputeStringMask                       | 1000    |    73,417.6 ns |  4,507.39 ns |   247.07 ns |
| ComputeStringMaskWithNullableArray      | 1000    |   100,192.4 ns |    565.15 ns |    30.98 ns |
| **ComputeIntEqualityMask**                  | **10000**   |    **18,051.6 ns** |  **2,170.90 ns** |   **118.99 ns** |
| ComputeIntEqualityMaskWithNullableArray | 10000   |   329,713.7 ns |  4,769.60 ns |   261.44 ns |
| ComputeIntRangeMask                     | 10000   |    31,168.1 ns |  2,605.88 ns |   142.84 ns |
| ComputeIntRangeMaskWithNullableArray    | 10000   |   309,563.2 ns |  9,139.37 ns |   500.96 ns |
| ComputeDateRangeMask                    | 10000   |    35,076.7 ns | 16,668.99 ns |   913.68 ns |
| ComputeDateRangeMaskWithNullableArray   | 10000   |   372,787.6 ns |  6,483.50 ns |   355.38 ns |
| ComputeStringMask                       | 10000   |   749,768.3 ns | 54,944.34 ns | 3,011.68 ns |
| ComputeStringMaskWithNullableArray      | 10000   | 1,012,841.5 ns | 29,622.43 ns | 1,623.71 ns |

