### PR TITLE
Fix reading all row groups when none are selected

### DIFF
--- a/ParquetSharp.Dataset.Test/InstrumentedFilter.cs
+++ b/ParquetSharp.Dataset.Test/InstrumentedFilter.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Apache.Arrow;
+using ParquetSharp.Dataset.Filter;
+
+namespace ParquetSharp.Dataset.Test;
+
+internal sealed class InstrumentedFilter : IFilter
+{
+    public InstrumentedFilter(IFilter filter)
+    {
+        _filter = filter;
+    }
+
+    public int IncludePartitionCallCount { get; private set; }
+
+    public int IncludeRowGroupCallCount { get; private set; }
+
+    public int ComputeMaskRowCount { get; private set; }
+
+    public bool IncludePartition(PartitionInformation partitionInformation)
+    {
+        ++IncludePartitionCallCount;
+        return _filter.IncludePartition(partitionInformation);
+    }
+
+    public bool IncludeRowGroup(IReadOnlyDictionary<string, LogicalStatistics> columnStatistics)
+    {
+        ++IncludeRowGroupCallCount;
+        return _filter.IncludeRowGroup(columnStatistics);
+    }
+
+    public FilterMask? ComputeMask(RecordBatch dataBatch)
+    {
+        ComputeMaskRowCount += dataBatch.Length;
+        return _filter.ComputeMask(dataBatch);
+    }
+
+    public IEnumerable<string> Columns()
+    {
+        return _filter.Columns();
+    }
+
+    private readonly IFilter _filter;
+}

--- a/ParquetSharp.Dataset.Test/TestDatasetReader.cs
+++ b/ParquetSharp.Dataset.Test/TestDatasetReader.cs
@@ -70,12 +70,18 @@ public class TestDatasetReader
             new Dictionary<string, int> { { "a", 20 }, { "b", 20 } });
 
         // Read filtered on partition
-        var filter = Col.Named("part").IsEqualTo("b");
+        var filter = new InstrumentedFilter(Col.Named("part").IsEqualTo("b"));
         using var filteredReader = dataset.ToBatches(filter);
         await VerifyData(
             filteredReader,
             new Dictionary<int, int> { { 2, 10 }, { 3, 10 } },
             new Dictionary<string, int> { { "b", 20 } });
+
+        // IncludePartition is called for the root directory and 2 subdirectories
+        Assert.That(filter.IncludePartitionCallCount, Is.EqualTo(3));
+        // No data files are used in the filter, so row group filtering is not used
+        Assert.That(filter.IncludeRowGroupCallCount, Is.EqualTo(0));
+        Assert.That(filter.ComputeMaskRowCount, Is.EqualTo(20));
     }
 
     [Test]
@@ -295,10 +301,15 @@ public class TestDatasetReader
             new NoPartitioning(),
             schema: schema);
 
-        var filter = Col.Named("id").IsInRange(0, 1);
+        var filter = new InstrumentedFilter(Col.Named("id").IsInRange(0, 1));
         using var reader = dataset.ToBatches(filter);
 
         await VerifyData(reader, new Dictionary<int, int> { { 0, 10 }, { 1, 10 } });
+
+        Assert.That(filter.IncludePartitionCallCount, Is.EqualTo(1));
+        Assert.That(filter.IncludeRowGroupCallCount, Is.EqualTo(4));
+        // Should only read data from one row group (10 rows) from each file
+        Assert.That(filter.ComputeMaskRowCount, Is.EqualTo(20));
     }
 
     [Test]
@@ -321,10 +332,15 @@ public class TestDatasetReader
             new NoPartitioning(),
             schema: schema);
 
-        var filter = Col.Named("id").IsEqualTo(2);
+        var filter = new InstrumentedFilter(Col.Named("id").IsEqualTo(2));
         using var reader = dataset.ToBatches(filter);
 
         await VerifyData(reader, new Dictionary<int, int> { { 2, 10 } });
+
+        Assert.That(filter.IncludePartitionCallCount, Is.EqualTo(1));
+        Assert.That(filter.IncludeRowGroupCallCount, Is.EqualTo(4));
+        // Should only read data from one row group (10 rows) from the second file
+        Assert.That(filter.ComputeMaskRowCount, Is.EqualTo(10));
     }
 
     [Test]

--- a/ParquetSharp.Dataset/DatasetStreamReader.cs
+++ b/ParquetSharp.Dataset/DatasetStreamReader.cs
@@ -115,6 +115,7 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
             var rowGroups = _rowGroupSelector?.GetRequiredRowGroups(_currentFileReader);
             if (rowGroups != null && rowGroups.Length == 0)
             {
+                _currentFileReader.Dispose();
                 continue;
             }
 

--- a/ParquetSharp.Dataset/DatasetStreamReader.cs
+++ b/ParquetSharp.Dataset/DatasetStreamReader.cs
@@ -107,22 +107,27 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
         _currentFragmentReader?.Dispose();
         _currentFileReader?.Dispose();
 
-        if (_fragmentEnumerator.MoveNext())
+        while (_fragmentEnumerator.MoveNext())
         {
             _currentFileReader = new FileReader(
                 _fragmentEnumerator.Current.FilePath, _readerProperties, _arrowReaderProperties);
 
             var rowGroups = _rowGroupSelector?.GetRequiredRowGroups(_currentFileReader);
+            if (rowGroups != null && rowGroups.Length == 0)
+            {
+                continue;
+            }
+
             var columnIndices = GetFileColumnIndices(_currentFileReader);
 
             _currentFragmentReader = _currentFileReader.GetRecordBatchReader(
                 rowGroups: rowGroups, columns: columnIndices);
+
+            return;
         }
-        else
-        {
-            _currentFileReader = null;
-            _currentFragmentReader = null;
-        }
+
+        _currentFileReader = null;
+        _currentFragmentReader = null;
     }
 
     private int[] GetFileColumnIndices(FileReader fileReader)

--- a/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
@@ -26,7 +26,7 @@ internal sealed class DateRangeEvaluator :
             var endNumber = _end.DayNumber - ArrowEpoch.DayNumber;
             if (inputArray.NullCount == 0)
             {
-                var values = array.Values;
+                var values = inputArray.Values;
                 for (var i = 0; i < inputArray.Length; ++i)
                 {
                     var value = values[i];
@@ -38,7 +38,7 @@ internal sealed class DateRangeEvaluator :
             {
                 for (var i = 0; i < inputArray.Length; ++i)
                 {
-                    var value = array.GetValue(i);
+                    var value = inputArray.GetValue(i);
                     var isInRange = value.HasValue && value.Value >= startNumber && value.Value <= endNumber;
                     BitUtility.SetBit(mask, i, isInRange);
                 }
@@ -54,7 +54,7 @@ internal sealed class DateRangeEvaluator :
         {
             for (var i = 0; i < inputArray.Length; ++i)
             {
-                var value = array.GetDateOnly(i);
+                var value = inputArray.GetDateOnly(i);
                 var isInRange = value.HasValue && value.Value >= _start && value.Value <= _end;
                 BitUtility.SetBit(mask, i, isInRange);
             }


### PR DESCRIPTION
Calling `FileReader.GetRecordBatchReader` with an empty `rowGroups` parameter is treated the same as null and means read all row groups, so when we don't want to read any row groups, skip creating a record batch reader completely.