### PR TITLE
Make range filters use exclusive upper bounds

### DIFF
--- a/ParquetSharp.Dataset.Test/Filter/TestDateFilter.cs
+++ b/ParquetSharp.Dataset.Test/Filter/TestDateFilter.cs
@@ -17,7 +17,7 @@ public class TestDateFilter<TArray, TUnderlying, TBuilder>
     public void TestComputeMask()
     {
         var rangeStart = new DateOnly(2024, 2, 1);
-        var rangeEnd = new DateOnly(2024, 2, 10);
+        var rangeEnd = new DateOnly(2024, 2, 11);
         var filter = Col.Named("date").IsInRange(rangeStart, rangeEnd);
 
         var dateValues = Enumerable.Range(0, 100)
@@ -50,7 +50,7 @@ public class TestDateFilter
     [Test]
     public void TestComputeMaskWithInvalidColumnType()
     {
-        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 10));
+        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 11));
 
         var dateArray = new Int32Array.Builder()
             .AppendRange(Enumerable.Range(0, 100))
@@ -67,7 +67,7 @@ public class TestDateFilter
     [Test]
     public void TestIncludeRowGroup()
     {
-        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 10));
+        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 1), new DateOnly(2024, 2, 11));
 
         foreach (var (min, max, expectInclude) in new[]
                  {

--- a/ParquetSharp.Dataset.Test/Filter/TestIntFilter.cs
+++ b/ParquetSharp.Dataset.Test/Filter/TestIntFilter.cs
@@ -219,7 +219,7 @@ public class TestIntFilter
                 try
                 {
                     var asLong = checkedCast(arrayValue.Value);
-                    isInRange = asLong >= rangeStart && asLong <= rangeEnd;
+                    isInRange = asLong >= rangeStart && asLong < rangeEnd;
                 }
                 catch (OverflowException)
                 {
@@ -228,7 +228,7 @@ public class TestIntFilter
 
             Assert.That(
                 isIncluded, Is.EqualTo(isInRange),
-                $"Expected {typeof(T)} value {arrayValue} inclusion to be {isInRange}");
+                $"Expected {typeof(T)} value {arrayValue} inclusion to be {isInRange} for range [{rangeStart}, {rangeEnd})");
         }
     }
 
@@ -301,7 +301,7 @@ public class TestIntFilter
             try
             {
                 var longMin = checkedCast(statsRange.min);
-                if (longMin > rangeEnd)
+                if (longMin >= rangeEnd)
                 {
                     rangesOverlap = false;
                 }

--- a/ParquetSharp.Dataset.Test/Filter/TestRowGroupSelector.cs
+++ b/ParquetSharp.Dataset.Test/Filter/TestRowGroupSelector.cs
@@ -63,7 +63,7 @@ public class TestRowGroupSelector
         var batch2 = GenerateBatch(20, 30);
         WriteParquetFile(filePath, new[] { batch0, batch1, batch2 }, includeStats: enableStatistics);
 
-        var filter = Col.Named("id").IsInRange(15, 25);
+        var filter = Col.Named("id").IsInRange(15, 26);
         var rowGroupSelector = new RowGroupSelector(filter);
 
         using var reader = new FileReader(filePath);
@@ -83,7 +83,7 @@ public class TestRowGroupSelector
         var batch2 = GenerateBatchWithDateColumn(new DateOnly(2024, 3, 1), new DateOnly(2024, 3, 31));
         WriteParquetFile(filePath, new[] { batch0, batch1, batch2 }, includeStats: enableStatistics);
 
-        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 5), new DateOnly(2024, 3, 5));
+        var filter = Col.Named("date").IsInRange(new DateOnly(2024, 2, 5), new DateOnly(2024, 3, 6));
         var rowGroupSelector = new RowGroupSelector(filter);
 
         using var reader = new FileReader(filePath);

--- a/ParquetSharp.Dataset.Test/TestDatasetReader.cs
+++ b/ParquetSharp.Dataset.Test/TestDatasetReader.cs
@@ -328,7 +328,7 @@ public class TestDatasetReader
             new NoPartitioning(),
             schema: schema);
 
-        var filter = new InstrumentedFilter(Col.Named("id").IsInRange(0, 1));
+        var filter = new InstrumentedFilter(Col.Named("id").IsInRange(0, 2));
         using var reader = dataset.ToBatches(filter);
 
         await VerifyData(reader, new Dictionary<int, int> { { 0, 10 }, { 1, 10 } });
@@ -826,7 +826,7 @@ public class TestDatasetReader
         var filters = new[]
         {
             (Col.Named("part").IsEqualTo(3), "part"),
-            (Col.Named("part").IsInRange(1, 5), "part"),
+            (Col.Named("part").IsInRange(1, 6), "part"),
             (Col.Named("part_id").IsEqualTo("abc"), "part_id"),
         };
 

--- a/ParquetSharp.Dataset/ColExtensions.cs
+++ b/ParquetSharp.Dataset/ColExtensions.cs
@@ -23,8 +23,8 @@ public static class ColExtensions
     /// Filter based on an integer typed column being within a specified range
     /// </summary>
     /// <param name="column">The column to add the condition on</param>
-    /// <param name="start">The first value of the range (inclusive)</param>
-    /// <param name="end">The last value of the range (inclusive)</param>
+    /// <param name="start">The start value of the range (inclusive)</param>
+    /// <param name="end">The end value of the range (exclusive)</param>
     /// <returns>Created filter</returns>
     public static IFilter IsInRange(this Col column, long start, long end)
     {
@@ -58,8 +58,8 @@ public static class ColExtensions
     /// Filter based on a date typed column being within a specified date range
     /// </summary>
     /// <param name="column">The date column to add the condition on</param>
-    /// <param name="start">The first date of the range (inclusive)</param>
-    /// <param name="end">The last date of the range (inclusive)</param>
+    /// <param name="start">The start date of the range (inclusive)</param>
+    /// <param name="end">The end date of the range (exclusive)</param>
     /// <returns>Created filter</returns>
     public static IFilter IsInRange(this Col column, DateOnly start, DateOnly end)
     {

--- a/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/DateRangeEvaluator.cs
@@ -30,7 +30,7 @@ internal sealed class DateRangeEvaluator :
                 for (var i = 0; i < inputArray.Length; ++i)
                 {
                     var value = values[i];
-                    var isInRange = value >= startNumber && value <= endNumber;
+                    var isInRange = value >= startNumber && value < endNumber;
                     BitUtility.SetBit(mask, i, isInRange);
                 }
             }
@@ -39,7 +39,7 @@ internal sealed class DateRangeEvaluator :
                 for (var i = 0; i < inputArray.Length; ++i)
                 {
                     var value = inputArray.GetValue(i);
-                    var isInRange = value.HasValue && value.Value >= startNumber && value.Value <= endNumber;
+                    var isInRange = value.HasValue && value.Value >= startNumber && value.Value < endNumber;
                     BitUtility.SetBit(mask, i, isInRange);
                 }
             }
@@ -55,7 +55,7 @@ internal sealed class DateRangeEvaluator :
             for (var i = 0; i < inputArray.Length; ++i)
             {
                 var value = inputArray.GetDateOnly(i);
-                var isInRange = value.HasValue && value.Value >= _start && value.Value <= _end;
+                var isInRange = value.HasValue && value.Value >= _start && value.Value < _end;
                 BitUtility.SetBit(mask, i, isInRange);
             }
         });

--- a/ParquetSharp.Dataset/Filter/DateRangeStatisticsEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/DateRangeStatisticsEvaluator.cs
@@ -18,7 +18,7 @@ internal sealed class DateRangeStatisticsEvaluator
 
     public bool Visit(LogicalStatistics<DateOnly> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     private readonly DateOnly _start;

--- a/ParquetSharp.Dataset/Filter/IntRangeEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/IntRangeEvaluator.cs
@@ -28,13 +28,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < 0 || _start > byte.MaxValue)
+            if (_end <= 0 || _start > byte.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (byte)Math.Max(_start, 0L), (byte)Math.Min(_end, byte.MaxValue));
+                var end = _end > byte.MaxValue ? null : (byte?)_end;
+                ComputeMask(mask, inputArray, (byte)Math.Max(_start, 0L), end);
             }
         });
     }
@@ -43,13 +44,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < 0 || _start > ushort.MaxValue)
+            if (_end <= 0 || _start > ushort.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (ushort)Math.Max(_start, 0L), (ushort)Math.Min(_end, ushort.MaxValue));
+                var end = _end > ushort.MaxValue ? null : (ushort?)_end;
+                ComputeMask(mask, inputArray, (ushort)Math.Max(_start, 0L), end);
             }
         });
     }
@@ -58,13 +60,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < 0 || _start > uint.MaxValue)
+            if (_end <= 0 || _start > uint.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (uint)Math.Max(_start, 0L), (uint)Math.Min(_end, uint.MaxValue));
+                var end = _end > uint.MaxValue ? null : (uint?)_end;
+                ComputeMask(mask, inputArray, (uint)Math.Max(_start, 0L), end);
             }
         });
     }
@@ -73,7 +76,7 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < 0)
+            if (_end <= 0)
             {
                 mask.AsSpan().Fill(0);
             }
@@ -88,13 +91,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < sbyte.MinValue || _start > sbyte.MaxValue)
+            if (_end <= sbyte.MinValue || _start > sbyte.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (sbyte)Math.Max(_start, sbyte.MinValue), (sbyte)Math.Min(_end, sbyte.MaxValue));
+                var end = _end > sbyte.MaxValue ? null : (sbyte?)_end;
+                ComputeMask(mask, inputArray, (sbyte)Math.Max(_start, sbyte.MinValue), end);
             }
         });
     }
@@ -103,13 +107,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < short.MinValue || _start > short.MaxValue)
+            if (_end <= short.MinValue || _start > short.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (short)Math.Max(_start, short.MinValue), (short)Math.Min(_end, short.MaxValue));
+                var end = _end > short.MaxValue ? null : (short?)_end;
+                ComputeMask(mask, inputArray, (short)Math.Max(_start, short.MinValue), end);
             }
         });
     }
@@ -118,13 +123,14 @@ internal sealed class IntRangeEvaluator :
     {
         BuildMask(array, (mask, inputArray) =>
         {
-            if (_end < int.MinValue || _start > int.MaxValue)
+            if (_end <= int.MinValue || _start > int.MaxValue)
             {
                 mask.AsSpan().Fill(0);
             }
             else
             {
-                ComputeMask(mask, inputArray, (int)Math.Max(_start, int.MinValue), (int)Math.Min(_end, int.MaxValue));
+                var end = _end > int.MaxValue ? null : (int?)_end;
+                ComputeMask(mask, inputArray, (int)Math.Max(_start, int.MinValue), end);
             }
         });
     }
@@ -134,7 +140,7 @@ internal sealed class IntRangeEvaluator :
         BuildMask(array, (mask, inputArray) => ComputeMask(mask, inputArray, _start, _end));
     }
 
-    private static void ComputeMask<T, TArray>(byte[] mask, TArray array, T rangeStart, T rangeEnd)
+    private static void ComputeMask<T, TArray>(byte[] mask, TArray array, T rangeStart, T? rangeEnd)
         where T : struct, IComparable<T>
         where TArray : PrimitiveArray<T>
     {
@@ -144,7 +150,7 @@ internal sealed class IntRangeEvaluator :
             for (var i = 0; i < array.Length; ++i)
             {
                 var value = values[i];
-                BitUtility.SetBit(mask, i, value.CompareTo(rangeStart) >= 0 && value.CompareTo(rangeEnd) <= 0);
+                BitUtility.SetBit(mask, i, value.CompareTo(rangeStart) >= 0 && (!rangeEnd.HasValue || value.CompareTo(rangeEnd.Value) < 0));
             }
         }
         else
@@ -154,7 +160,7 @@ internal sealed class IntRangeEvaluator :
                 var value = array.GetValue(i);
                 BitUtility.SetBit(
                     mask, i,
-                    value.HasValue && value.Value.CompareTo(rangeStart) >= 0 && value.Value.CompareTo(rangeEnd) <= 0);
+                    value.HasValue && value.Value.CompareTo(rangeStart) >= 0 && (!rangeEnd.HasValue || value.Value.CompareTo(rangeEnd.Value) < 0));
             }
         }
     }

--- a/ParquetSharp.Dataset/Filter/IntRangeStatisticsEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/IntRangeStatisticsEvaluator.cs
@@ -23,42 +23,42 @@ internal sealed class IntRangeStatisticsEvaluator
 
     public bool Visit(LogicalStatistics<byte> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<ushort> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<uint> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<ulong> stats)
     {
-        return (_end >= 0 && (ulong)_end >= stats.Min) && (_start < 0 || (ulong)_start <= stats.Max);
+        return (_end > 0 && (ulong)_end > stats.Min) && (_start < 0 || (ulong)_start <= stats.Max);
     }
 
     public bool Visit(LogicalStatistics<sbyte> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<short> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<int> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     public bool Visit(LogicalStatistics<long> stats)
     {
-        return _end >= stats.Min && _start <= stats.Max;
+        return _end > stats.Min && _start <= stats.Max;
     }
 
     private readonly long _start;

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0-beta3</VersionPrefix>
+    <VersionPrefix>0.1.0-beta4</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp.Dataset</Product>


### PR DESCRIPTION
This is more consistent with how most APIs in other systems use ranges, and will be easier to work with when we support timestamp ranges.