### PR TITLE
Fix incompatibility with Arrow 17.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Code formating check
         run: |
           dotnet tool restore
@@ -53,7 +53,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Get version
       id: get-version
       shell: pwsh
@@ -84,14 +84,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet: [net6.0, net7.0]
+        dotnet: [net8.0, net9.0]
         arrow: [15.0.1]
         include:
           - os: ubuntu-latest
-            dotnet: net7.0
+            dotnet: net8.0
             arrow: 18.1.0
           - os: ubuntu-latest
-            dotnet: net7.0
+            dotnet: net8.0
             arrow: 19.0.1
       fail-fast: false
     name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }} with Arrow ${{ matrix.arrow }})
@@ -105,15 +105,15 @@ jobs:
       with:
         name: nuget-package
         path: nuget
-    - name: Setup .NET 6 SDK
-      if: matrix.dotnet == 'net6.0'
+    - name: Setup .NET 8 SDK
+      if: matrix.dotnet == 'net8.0'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-    - name: Setup .NET 7 SDK
+        dotnet-version: 8.0.x
+    - name: Setup .NET 9 SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 9.0.x
     - name: Add local NuGet feed
       run: |
         dotnet new nugetconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dotnet: [net6.0, net7.0]
+        arrow: [15.0.1]
+        include:
+          - os: ubuntu-latest
+            dotnet: net7.0
+            arrow: 18.1.0
+          - os: ubuntu-latest
+            dotnet: net7.0
+            arrow: 19.0.1
       fail-fast: false
-    name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }})
+    name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }} with Arrow ${{ matrix.arrow }})
     runs-on: ${{ matrix.os }}
     needs: build-nuget
     steps:
@@ -114,6 +122,9 @@ jobs:
       run: |
         dotnet remove ParquetSharp.Dataset.Test reference ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
         dotnet add ParquetSharp.Dataset.Test package ParquetSharp.Dataset -v ${{ needs.build-nuget.outputs.version }}
+    - name: Install Apache Arrow version
+      run: |
+        dotnet add ParquetSharp.Dataset.Test package Apache.Arrow -v ${{ matrix.arrow }}
     - name: Build & Run .NET unit tests
       run: dotnet test ParquetSharp.Dataset.Test --configuration=Release --framework ${{ matrix.dotnet }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Code formating check
         run: |
           dotnet tool restore

--- a/ParquetSharp.Dataset.Benchmark/ParquetSharp.Dataset.Benchmark.csproj
+++ b/ParquetSharp.Dataset.Benchmark/ParquetSharp.Dataset.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/ParquetSharp.Dataset.Test/Filter/TestIntFilter.cs
+++ b/ParquetSharp.Dataset.Test/Filter/TestIntFilter.cs
@@ -158,7 +158,7 @@ public class TestIntFilter
     }
 
     private static void TestComputeIntEqualityMask<T, TArray, TBuilder>(long filterValue, T[] values, Func<T, long> checkedCast)
-        where T : struct
+        where T : struct, IEquatable<T>
         where TArray : PrimitiveArray<T>
         where TBuilder : PrimitiveArrayBuilder<T, TArray, TBuilder>, new()
     {
@@ -195,7 +195,7 @@ public class TestIntFilter
     }
 
     private static void TestComputeIntRangeMask<T, TArray, TBuilder>(long rangeStart, long rangeEnd, T[] values, Func<T, long> checkedCast)
-        where T : struct
+        where T : struct, IEquatable<T>
         where TArray : PrimitiveArray<T>
         where TBuilder : PrimitiveArrayBuilder<T, TArray, TBuilder>, new()
     {

--- a/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
+++ b/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>

--- a/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
+++ b/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
+++ b/ParquetSharp.Dataset.Test/ParquetSharp.Dataset.Test.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>

--- a/ParquetSharp.Dataset/ConstantArrayCreator.cs
+++ b/ParquetSharp.Dataset/ConstantArrayCreator.cs
@@ -118,7 +118,7 @@ internal sealed class ConstantArrayCreator
     }
 
     private ArrayData VisitPrimitiveArray<T, TArray>(TArray array)
-        where T : struct
+        where T : struct, IEquatable<T>
         where TArray : PrimitiveArray<T>
     {
         var value = array.GetValue(0);

--- a/ParquetSharp.Dataset/Filter/ArrayMaskApplier.cs
+++ b/ParquetSharp.Dataset/Filter/ArrayMaskApplier.cs
@@ -229,7 +229,7 @@ public class ArrayMaskApplier :
     }
 
     private void VisitPrimitiveArray<T, TArray>(TArray array, Func<ArrayData, TArray> arrayConstructor)
-        where T : struct
+        where T : struct, IEquatable<T>
         where TArray : PrimitiveArray<T>
     {
         var valueBuffer = new ArrowBuffer.Builder<T>(_includedCount);

--- a/ParquetSharp.Dataset/Filter/IntRangeEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/IntRangeEvaluator.cs
@@ -141,7 +141,7 @@ internal sealed class IntRangeEvaluator :
     }
 
     private static void ComputeMask<T, TArray>(byte[] mask, TArray array, T rangeStart, T? rangeEnd)
-        where T : struct, IComparable<T>
+        where T : struct, IComparable<T>, IEquatable<T>
         where TArray : PrimitiveArray<T>
     {
         if (array.NullCount == 0)

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0-beta4</VersionPrefix>
+    <VersionPrefix>0.1.0</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp.Dataset</Product>


### PR DESCRIPTION
Arrow 17.0.0 made a change to `PrimitiveArray`, requiring that its type parameter `T` implements `IEquatable<T>`: https://github.com/apache/arrow/pull/41539

This causes a runtime error when using ParquetSharp.Dataset and methods are called that have a generic parameter constrained to be a primitive array, eg:
```
System.TypeLoadException : GenericArguments[0], 'T', on 'Apache.Arrow.PrimitiveArray`1[T]' violates the constraint of type parameter 'T'.
   at ParquetSharp.Dataset.ConstantArrayCreator.Visit(Int32Array array)
   at Apache.Arrow.Int32Array.Accept(IArrowArrayVisitor visitor)
   at ParquetSharp.Dataset.FragmentExpander.ExpandBatch(RecordBatch fragmentBatch, PartitionInformation partitionInfo) in /home/adam/dev/gross/ParquetSharp.Dataset/ParquetSharp.Dataset/FragmentExpander.cs:line 51
   at ParquetSharp.Dataset.DatasetStreamReader.ReadNextRecordBatchAsync(CancellationToken cancellationToken) in /home/adam/dev/gross/ParquetSharp.Dataset/ParquetSharp.Dataset/DatasetStreamReader.cs:line 58
```

This PR updates our CI to test against multiple Arrow versions, and adds this extra type constraint on methods that take a `PrimitiveArrray<T>` to fix the error.