### PR TITLE
Bump ParquetSharp dependency to stable 15.0.2.1 release

### DIFF
--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ParquetSharp" Version="15.0.2-beta1" />
+    <PackageReference Include="ParquetSharp" Version="15.0.2.1" />
     <PackageReference Include="Apache.Arrow" Version="15.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Having a dependency on a pre-release version caused building the 0.1.0 version to fail: https://github.com/G-Research/ParquetSharp.Dataset/actions/runs/13934266483/job/38998617679