### PR TITLE
Add support for Arrow LargeString, LargeBinary and LargeList types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dotnet: [net8.0, net9.0]
-        arrow: [15.0.1]
+        arrow: [18.0.0]
         include:
           - os: ubuntu-latest
             dotnet: net8.0
@@ -93,6 +93,9 @@ jobs:
           - os: ubuntu-latest
             dotnet: net8.0
             arrow: 19.0.1
+          - os: ubuntu-latest
+            dotnet: net8.0
+            arrow: 20.0.0
       fail-fast: false
     name: Test NuGet package (.NET ${{ matrix.dotnet }} on ${{ matrix.os }} with Arrow ${{ matrix.arrow }})
     runs-on: ${{ matrix.os }}

--- a/ParquetSharp.Dataset.Test/Filter/TestArrayMaskApplier.cs
+++ b/ParquetSharp.Dataset.Test/Filter/TestArrayMaskApplier.cs
@@ -171,6 +171,7 @@ public class TestArrayMaskApplier
                 (builder, _) => builder.AppendNull()),
             BuildDictionaryArray(numRows, random),
             BuildListArray(numRows, random),
+            BuildLargeListArray(numRows, random),
             BuildStructArray(numRows, random),
             BuildMapArray(numRows, random),
         };
@@ -294,6 +295,48 @@ public class TestArrayMaskApplier
         }
 
         return builder.Build();
+    }
+
+    private static IArrowArray BuildLargeListArray(int numRows, Random random)
+    {
+        var valuesBuilder = new Int64Array.Builder();
+        var offsetBuffer = new ArrowBuffer.Builder<long>();
+        var validityBuffer = new ArrowBuffer.BitmapBuilder();
+
+        long offset = 0;
+        offsetBuffer.Append(offset);
+        for (var rowIdx = 0; rowIdx < numRows; ++rowIdx)
+        {
+            if (random.NextDouble() < 0.1)
+            {
+                validityBuffer.Append(false);
+                offsetBuffer.Append(offset);
+            }
+            else
+            {
+                var listLength = random.NextInt64(0, 10);
+                for (var itemIdx = 0; itemIdx < listLength; ++itemIdx)
+                {
+                    if (random.NextDouble() < 0.1)
+                    {
+                        valuesBuilder.AppendNull();
+                    }
+                    else
+                    {
+                        valuesBuilder.Append(random.NextInt64(-100, 100));
+                    }
+                }
+
+                offset += listLength;
+                offsetBuffer.Append(offset);
+                validityBuffer.Append(true);
+            }
+        }
+
+        return new LargeListArray(
+            new LargeListType(new Int64Type()), numRows,
+            offsetBuffer.Build(), valuesBuilder.Build(), validityBuffer.Build(),
+            validityBuffer.UnsetBitCount);
     }
 
     private static IArrowArray BuildStructArray(int numRows, Random random)
@@ -434,6 +477,7 @@ public class TestArrayMaskApplier
         , IArrowArrayVisitor<NullArray>
         , IArrowArrayVisitor<DictionaryArray>
         , IArrowArrayVisitor<ListArray>
+        , IArrowArrayVisitor<LargeListArray>
         , IArrowArrayVisitor<StructArray>
     {
         public MaskedArrayValidator(IArrowArray sourceArray, FilterMask? mask)
@@ -509,6 +553,40 @@ public class TestArrayMaskApplier
         public void Visit(ListArray array)
         {
             if (_sourceArray is not ListArray sourceArray)
+            {
+                throw new Exception(
+                    $"Masked array ({array}) does not have the same type as the source array ({_sourceArray})");
+            }
+
+            Assert.That(array.Length, Is.EqualTo(_expectedLength));
+
+            var outputIndex = 0;
+            for (var i = 0; i < sourceArray.Length; ++i)
+            {
+                if (_mask == null || BitUtility.GetBit(_mask.Mask.Span, i))
+                {
+                    var sourceList = sourceArray.GetSlicedValues(i);
+                    var outputList = array.GetSlicedValues(outputIndex);
+                    if (sourceList == null)
+                    {
+                        Assert.That(outputList, Is.Null);
+                    }
+                    else
+                    {
+                        var listValidator = new MaskedArrayValidator(sourceList, mask: null);
+                        outputList.Accept(listValidator);
+                    }
+
+                    outputIndex++;
+                }
+            }
+
+            Assert.That(outputIndex, Is.EqualTo(_expectedLength));
+        }
+
+        public void Visit(LargeListArray array)
+        {
+            if (_sourceArray is not LargeListArray sourceArray)
             {
                 throw new Exception(
                     $"Masked array ({array}) does not have the same type as the source array ({_sourceArray})");

--- a/ParquetSharp.Dataset/Filter/ArrayMaskApplier.cs
+++ b/ParquetSharp.Dataset/Filter/ArrayMaskApplier.cs
@@ -360,7 +360,7 @@ public class ArrayMaskApplier :
         where TArray : BinaryArray
     {
         var dataBuffer = new ArrowBuffer.Builder<byte>();
-        var valueOffsetsBuffer = new ArrowBuffer.Builder<int>(_includedCount);
+        var valueOffsetsBuffer = new ArrowBuffer.Builder<int>(_includedCount + 1);
         var validityBuffer = new ArrowBuffer.BitmapBuilder(_includedCount);
 
         var sourceOffsets = array.ValueOffsets;
@@ -396,7 +396,7 @@ public class ArrayMaskApplier :
         where TArray : LargeBinaryArray
     {
         var dataBuffer = new ArrowBuffer.Builder<byte>();
-        var valueOffsetsBuffer = new ArrowBuffer.Builder<long>(_includedCount);
+        var valueOffsetsBuffer = new ArrowBuffer.Builder<long>(_includedCount + 1);
         var validityBuffer = new ArrowBuffer.BitmapBuilder(_includedCount);
 
         var sourceOffsets = array.ValueOffsets;

--- a/ParquetSharp.Dataset/Filter/StringInSetEvaluator.cs
+++ b/ParquetSharp.Dataset/Filter/StringInSetEvaluator.cs
@@ -7,7 +7,10 @@ namespace ParquetSharp.Dataset.Filter;
 /// <summary>
 /// Tests whether an array contains a single string within a set of specified values
 /// </summary>
-internal sealed class StringInSetEvaluator : BaseFilterEvaluator, IArrowArrayVisitor<StringArray>
+internal sealed class StringInSetEvaluator :
+    BaseFilterEvaluator
+    , IArrowArrayVisitor<StringArray>
+    , IArrowArrayVisitor<LargeStringArray>
 {
     public StringInSetEvaluator(IReadOnlyCollection<string?> values, string columnName)
     {
@@ -16,6 +19,17 @@ internal sealed class StringInSetEvaluator : BaseFilterEvaluator, IArrowArrayVis
     }
 
     public void Visit(StringArray array)
+    {
+        BuildMask(array, (mask, inputArray) =>
+        {
+            for (var i = 0; i < inputArray.Length; ++i)
+            {
+                BitUtility.SetBit(mask, i, _allowedValues.Contains(array.GetString(i)));
+            }
+        });
+    }
+
+    public void Visit(LargeStringArray array)
     {
         BuildMask(array, (mask, inputArray) =>
         {

--- a/ParquetSharp.Dataset/FragmentExpander.cs
+++ b/ParquetSharp.Dataset/FragmentExpander.cs
@@ -99,8 +99,8 @@ internal sealed class FragmentExpander
             ArrowTypeId.Timestamp => new TimestampArray.Builder(),
             ArrowTypeId.Time32 => new Time32Array.Builder(),
             ArrowTypeId.Time64 => new Time64Array.Builder(),
-            ArrowTypeId.Decimal128 => new Decimal128Array.Builder(dataType as Decimal128Type),
-            ArrowTypeId.Decimal256 => new Decimal256Array.Builder(dataType as Decimal256Type),
+            ArrowTypeId.Decimal128 => new Decimal128Array.Builder((dataType as Decimal128Type)!),
+            ArrowTypeId.Decimal256 => new Decimal256Array.Builder((dataType as Decimal256Type)!),
             ArrowTypeId.List => new ListArray.Builder((dataType as ListType)!.ValueDataType),
             ArrowTypeId.Map => new MapArray.Builder(dataType as MapType),
             ArrowTypeId.FixedSizeList => new FixedSizeListArray.Builder(

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="ParquetSharp" Version="15.0.2.1" />
-    <PackageReference Include="Apache.Arrow" Version="15.0.1" />
+    <PackageReference Include="Apache.Arrow" Version="18.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp.Dataset</Product>

--- a/ParquetSharp.Dataset/TypeComparer.cs
+++ b/ParquetSharp.Dataset/TypeComparer.cs
@@ -15,6 +15,7 @@ internal sealed class TypeComparer
         , IArrowTypeVisitor<FixedSizeListType>
         , IArrowTypeVisitor<IntervalType>
         , IArrowTypeVisitor<ListType>
+        , IArrowTypeVisitor<LargeListType>
         , IArrowTypeVisitor<ListViewType>
         , IArrowTypeVisitor<MapType>
         , IArrowTypeVisitor<StructType>
@@ -61,6 +62,20 @@ internal sealed class TypeComparer
     public void Visit(ListType type)
     {
         if (_expectedType is ListType expectedType)
+        {
+            var valueComparer = new TypeComparer(expectedType.ValueDataType);
+            type.ValueDataType.Accept(valueComparer);
+            TypesMatch = valueComparer.TypesMatch;
+        }
+        else
+        {
+            TypesMatch = false;
+        }
+    }
+
+    public void Visit(LargeListType type)
+    {
+        if (_expectedType is LargeListType expectedType)
         {
             var valueComparer = new TypeComparer(expectedType.ValueDataType);
             type.ValueDataType.Accept(valueComparer);


### PR DESCRIPTION
This is particularly useful for compatibility with Polars, which uses these large types when writing Parquet. These were added in .NET Arrow 18.0.0, so I've bumped the minimum version of Arrow required.