### PR TITLE
Dispose of Parquet RecordBatches when creating a new filtered batch

### DIFF
--- a/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
+++ b/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
@@ -78,7 +78,10 @@ public class DatasetRead
             using var batchReader = reader.GetRecordBatchReader();
             while (await batchReader.ReadNextRecordBatchAsync() is { } batch)
             {
-                rowsRead += batch.Length;
+                using (batch)
+                {
+                    rowsRead += batch.Length;
+                }
             }
         }
 
@@ -93,7 +96,10 @@ public class DatasetRead
         long rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         return rowsRead;
@@ -108,7 +114,10 @@ public class DatasetRead
         long rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         return rowsRead;
@@ -123,7 +132,10 @@ public class DatasetRead
         long rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         return rowsRead;
@@ -137,7 +149,10 @@ public class DatasetRead
         long rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         return rowsRead;
@@ -151,7 +166,10 @@ public class DatasetRead
         long rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         return rowsRead;

--- a/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
+++ b/ParquetSharp.Dataset.Benchmark/DatasetRead.cs
@@ -76,12 +76,10 @@ public class DatasetRead
         {
             using var reader = new FileReader(filePath);
             using var batchReader = reader.GetRecordBatchReader();
-            while (await batchReader.ReadNextRecordBatchAsync() is { } batch)
+            while (await batchReader.ReadNextRecordBatchAsync() is { } batch_)
             {
-                using (batch)
-                {
-                    rowsRead += batch.Length;
-                }
+                using var batch = batch_;
+                rowsRead += batch.Length;
             }
         }
 
@@ -94,12 +92,10 @@ public class DatasetRead
         var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
         using var reader = dataset.ToBatches();
         long rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         return rowsRead;
@@ -112,12 +108,10 @@ public class DatasetRead
         var filter = Col.Named("group").IsEqualTo("group-2").And(Col.Named("day").IsEqualTo(2));
         using var reader = dataset.ToBatches(filter);
         long rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         return rowsRead;
@@ -130,12 +124,10 @@ public class DatasetRead
         var filter = Col.Named("id").IsEqualTo(5);
         using var reader = dataset.ToBatches(filter);
         long rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         return rowsRead;
@@ -147,12 +139,10 @@ public class DatasetRead
         var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
         using var reader = dataset.ToBatches(columns: new[] { "id", "ints", "doubles" });
         long rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         return rowsRead;
@@ -164,12 +154,10 @@ public class DatasetRead
         var dataset = new DatasetReader(_datasetDirectory, new HivePartitioning.Factory());
         using var reader = dataset.ToBatches(columns: new[] { "ints" });
         long rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         return rowsRead;

--- a/ParquetSharp.Dataset.Test/TestEncryption.cs
+++ b/ParquetSharp.Dataset.Test/TestEncryption.cs
@@ -47,12 +47,10 @@ public class TestEncryption
         using var reader = dataset.ToBatches();
 
         var rowsRead = 0;
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
-            {
-                rowsRead += batch.Length;
-            }
+            using var batch = batch_;
+            rowsRead += batch.Length;
         }
 
         Assert.That(rowsRead, Is.EqualTo(originalBatch.Length));

--- a/ParquetSharp.Dataset.Test/TestEncryption.cs
+++ b/ParquetSharp.Dataset.Test/TestEncryption.cs
@@ -49,7 +49,10 @@ public class TestEncryption
         var rowsRead = 0;
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            rowsRead += batch.Length;
+            using (batch)
+            {
+                rowsRead += batch.Length;
+            }
         }
 
         Assert.That(rowsRead, Is.EqualTo(originalBatch.Length));

--- a/ParquetSharp.Dataset.Test/TestFilterParquet.cs
+++ b/ParquetSharp.Dataset.Test/TestFilterParquet.cs
@@ -98,15 +98,13 @@ public static class TestFilterParquet
         var dataset = new DatasetReader(datasetDir.DirectoryPath);
         using var reader = dataset.ToBatches(filter);
         var valuesRead = new List<int?>();
-        while (await reader.ReadNextRecordBatchAsync() is { } batch)
+        while (await reader.ReadNextRecordBatchAsync() is { } batch_)
         {
-            using (batch)
+            using var batch = batch_;
+            var filteredBatchValues = batch.Column(0) as Int32Array;
+            foreach (var value in filteredBatchValues!)
             {
-                var filteredBatchValues = batch.Column(0) as Int32Array;
-                foreach (var value in filteredBatchValues!)
-                {
-                    valuesRead.Add(value);
-                }
+                valuesRead.Add(value);
             }
         }
 

--- a/ParquetSharp.Dataset.Test/TestFilterParquet.cs
+++ b/ParquetSharp.Dataset.Test/TestFilterParquet.cs
@@ -100,10 +100,13 @@ public static class TestFilterParquet
         var valuesRead = new List<int?>();
         while (await reader.ReadNextRecordBatchAsync() is { } batch)
         {
-            var filteredBatchValues = batch.Column(0) as Int32Array;
-            foreach (var value in filteredBatchValues!)
+            using (batch)
             {
-                valuesRead.Add(value);
+                var filteredBatchValues = batch.Column(0) as Int32Array;
+                foreach (var value in filteredBatchValues!)
+                {
+                    valuesRead.Add(value);
+                }
             }
         }
 

--- a/ParquetSharp.Dataset/DatasetStreamReader.cs
+++ b/ParquetSharp.Dataset/DatasetStreamReader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -48,7 +49,7 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
             var nextBatch = await _currentFragmentReader.ReadNextRecordBatchAsync(cancellationToken);
             if (nextBatch != null)
             {
-                var filtered = FilterBatch(nextBatch);
+                var filtered = FilterBatch(ref nextBatch);
                 if (filtered == null)
                 {
                     // All rows excluded
@@ -70,9 +71,16 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
     /// <summary>
     /// Return a record batch with rows filtered out using the current filter.
     /// Returns null if all rows are excluded.
+    /// Takes ownership of the input record batch and will dispose it if it
+    /// is filtered.
     /// </summary>
-    private RecordBatch? FilterBatch(RecordBatch recordBatch)
+    private RecordBatch? FilterBatch(ref RecordBatch? recordBatch)
     {
+        if (recordBatch == null)
+        {
+            throw new ArgumentNullException(nameof(recordBatch));
+        }
+
         if (_filter == null)
         {
             return recordBatch;
@@ -101,6 +109,7 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
 
         // Dispose input record batch so its memory can be immediately freed
         recordBatch.Dispose();
+        recordBatch = null;
 
         return filteredBatch;
     }

--- a/ParquetSharp.Dataset/DatasetStreamReader.cs
+++ b/ParquetSharp.Dataset/DatasetStreamReader.cs
@@ -97,7 +97,12 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
             arrays.Add(filterApplier.MaskedArray);
         }
 
-        return new RecordBatch(recordBatch.Schema, arrays, filterMask.IncludedCount);
+        var filteredBatch = new RecordBatch(recordBatch.Schema, arrays, filterMask.IncludedCount);
+
+        // Dispose input record batch so its memory can be immediately freed
+        recordBatch.Dispose();
+
+        return filteredBatch;
     }
 
     public void Dispose()

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp.Dataset</Product>


### PR DESCRIPTION
This should allow the native memory backing the batch to be freed immediately without having to wait for a finalizer.

I've also updated the tests and benchmarks to dispose of record batches immediately as these should demonstrate best practice.