### PR TITLE
Allow ignoring files and directories using a prefix

### DIFF
--- a/ParquetSharp.Dataset/DatasetOptions.cs
+++ b/ParquetSharp.Dataset/DatasetOptions.cs
@@ -1,0 +1,19 @@
+namespace ParquetSharp.Dataset;
+
+/// <summary>
+/// Options that control behaviour when reading a Dataset,
+/// which aren't specific to a partitioning scheme or Parquet reading.
+/// </summary>
+public class DatasetOptions
+{
+    /// <summary>
+    /// Files and directories matching these prefixes will be ignored.
+    /// Defaults to "." and "_"
+    /// </summary>
+    public string[] IgnorePrefixes { get; init; } = { ".", "_" };
+
+    /// <summary>
+    /// The default DatasetOptions
+    /// </summary>
+    public static readonly DatasetOptions Default = new();
+}

--- a/ParquetSharp.Dataset/DatasetStreamReader.cs
+++ b/ParquetSharp.Dataset/DatasetStreamReader.cs
@@ -16,12 +16,13 @@ internal sealed class DatasetStreamReader : IArrowArrayStream
         string directory,
         Apache.Arrow.Schema schema,
         IPartitioning partitioning,
+        DatasetOptions options,
         IFilter? filter = null,
         ReaderProperties? readerProperties = null,
         ArrowReaderProperties? arrowReaderProperties = null)
     {
         Schema = schema;
-        _fragmentEnumerator = new FragmentEnumerator(directory, partitioning, filter);
+        _fragmentEnumerator = new FragmentEnumerator(directory, partitioning, options, filter);
         _fragmentExpander = new FragmentExpander(schema);
         _filter = filter;
         _readerProperties = readerProperties;

--- a/ParquetSharp.Dataset/FragmentEnumerator.cs
+++ b/ParquetSharp.Dataset/FragmentEnumerator.cs
@@ -165,7 +165,7 @@ internal sealed class FragmentEnumerator : IEnumerator<PartitionFragment>
     {
         foreach (var prefix in _options.IgnorePrefixes)
         {
-            if (fileName.StartsWith(prefix))
+            if (fileName.StartsWith(prefix, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
+++ b/ParquetSharp.Dataset/ParquetSharp.Dataset.csproj
@@ -5,7 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <Company>G-Research</Company>
     <Authors>G-Research</Authors>
     <Product>ParquetSharp.Dataset</Product>


### PR DESCRIPTION
Fixes #28 

Adds a new `DatasetOptions` class that could be expanded in future for other options, like controlling how files are inspected to determine the schema if we need to handle schema migrations.