### PR TITLE
chore: prevent invalid version suffixes being used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           $version_suffix=""
           $version="${version_prefix}"
         } else {
-          $version_suffix="$(git rev-parse --short HEAD)"
+          $version_suffix="sha$(git rev-parse --short HEAD)"
           $version="${version_prefix}-${version_suffix}"
         }
         echo "version=${version}"


### PR DESCRIPTION
Fix for this build failure: https://github.com/G-Research/ParquetSharp.Dataset/actions/runs/26521150876/job/78112237896

If a version suffix is fully numeric it can't have leading zeros. In this case the short form of the git sha broke this rule and the build failed. Prevent this by always prepending "sha" to the version suffix.